### PR TITLE
1111-1215 small eslint, gitignore, package.json fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,17 +11,21 @@
             "error",
             2
         ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
+		"quotes": [
             "error",
             "single"
         ],
-        "semi": [
+		"semi": [
             "error",
             "always"
         ],
-    },
+},
+	"globals": {
+	"describe": false,
+	"it": false,
+	"beforeEach": false,
+	"afterEach": false,
+	"before": false,
+	"after": false
+ }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+.env

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mizutombo/fanclub-app.git"
+    "url": "git+https://github.com/pdx-fanclub/fanclub-app"
   },
   "keywords": [
     "http",
@@ -21,9 +21,9 @@
   "author": "Tom Shultz",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/mizutombo/fanclub-app"
+    "url": "https://github.com/pdx-fanclub/fanclub-app/issues"
   },
-  "homepage": "https://github.com/mizutombo/fanclub-app#README",
+  "homepage": "https://github.com/fanclub-app#README",
   "dependencies": {
     "bcryptjs": "^2.3.0",
     "body-parser": "^1.15.2",


### PR DESCRIPTION
Eslint: removed linebreak enforcement (Unix/Windows conflict on this), add Mocha command exceptions as globals.
.gitignore: added ".env" to ignores.
package.JSON: fixed URLs to point to project page.