### PR TITLE
1116 1230 songs

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -13,6 +13,7 @@ const songs = require('./routes/songs');
 // const users = require('./routes/users');
 const syncSpotify = require('./routes/sync-spotify');
 const spotifyUser = require('./routes/spotify-user');
+const spotifySong = require('./routes/spotify-song');
 
 
 const checkAuth = require('./auth/check-auth')();  //middleware, no parameters
@@ -31,6 +32,7 @@ app.use('/api/songs', checkAuth, songs);
 app.use('/api/users', checkAuth);
 app.use('/api/sync-spotify', syncSpotify);
 app.use('/api/spotify-user', spotifyUser);
+app.use('/api/spotify-song', spotifySong);
 
 app.use(errorHandler);
 

--- a/lib/models/song.js
+++ b/lib/models/song.js
@@ -7,10 +7,10 @@ const schema = new Schema({
     required: true
   },
 
-  artist: {
+  artists: [{
     type: String,
     required: true
-  },
+  }],
 
   genre: {
     type: String,

--- a/lib/models/song.js
+++ b/lib/models/song.js
@@ -12,7 +12,7 @@ const schema = new Schema({
     required: true
   }],
 
-  genre: {
+  spotifySongId: {
     type: String,
     default: '',
   },

--- a/lib/routes/spotify-song.js
+++ b/lib/routes/spotify-song.js
@@ -1,0 +1,44 @@
+const spotifyApi = 'https://api.spotify.com/v1';
+const oauthToken = 'BQBjkLaPY5PkuSPUWB6rNaQY5MQGrP1an_zaf6Cl2tpzY0vkXpWNEegrYf8HTUnjgWshaH2r90j0ZATyIYi6ROENIM0Kd5B0G6ewZR4aTda2aQA7dYUsyKVieH3t1VYW9mQ5fIrwS2DGaktcZrINMs2EIBWk6-Gkag';
+const router = require('express').Router();
+const rp = require('request-promise');
+const Song = require('../models/song');
+
+router
+  // .get('/get-song', (req, res, next) => {
+  //   rp(`${spotifyApi}/tracks/6lFfwR8W6Ha4cA7kvmclcv?access_token=${oauthToken}`)
+  //     .then(data => {
+  //       var songData = new Song();
+  //       const spotifyData = JSON.parse(data);
+  //       songData.name = spotifyData.name;
+  //       songData.artists = [];
+  //       spotifyData.artists.forEach(artists => {
+  //         songData.artists.push(artists.name);
+  //       });
+  //       songData.save();
+  //       console.log(songData);
+  //       res.send(songData);
+  //
+  //     })
+  //     .catch(next);
+  // });
+  .get('/get-song/:id', (req, res, next) => {
+    rp(`${spotifyApi}/tracks/6lFfwR8W6Ha4cA7kvmclcv?access_token=${oauthToken}`)
+      .then(data => {
+        var songData = new Song();
+        const spotifyData = JSON.parse(data);
+        songData.name = spotifyData.name;
+        songData.artists = [];
+        spotifyData.artists.forEach(artists => {
+          songData.artists.push(artists.name);
+        });
+        songData.save();
+        console.log(songData);
+        res.send(songData);
+
+      })
+      .catch(next);
+  });
+
+
+module.exports = router;

--- a/lib/routes/spotify-song.js
+++ b/lib/routes/spotify-song.js
@@ -1,12 +1,13 @@
 const spotifyApi = 'https://api.spotify.com/v1';
-const oauthToken = 'BQBjkLaPY5PkuSPUWB6rNaQY5MQGrP1an_zaf6Cl2tpzY0vkXpWNEegrYf8HTUnjgWshaH2r90j0ZATyIYi6ROENIM0Kd5B0G6ewZR4aTda2aQA7dYUsyKVieH3t1VYW9mQ5fIrwS2DGaktcZrINMs2EIBWk6-Gkag';
+const oauthToken = 'BQDaQg6JxgnEiuSkehOPdk1rdYCWsfgVUxjUS0qkvitZ3RO385PcfMr-XI12NyoHu9StAkgnkM75zyYJH71cJxrbatR6nrySabqa1pmy78zqD-v6DPqIWau2B9ltDo3KNGoBiy_ze2JcoZJDzpFecyf8LEVbzLmZJg';
 const router = require('express').Router();
 const rp = require('request-promise');
 const Song = require('../models/song');
+const Playlist = require('../models/playlist');
 
 router
   // .get('/get-song', (req, res, next) => {
-  //   rp(`${spotifyApi}/tracks/6lFfwR8W6Ha4cA7kvmclcv?access_token=${oauthToken}`)
+    // rp(`${spotifyApi}/tracks/6lFfwR8W6Ha4cA7kvmclcv?access_token=${oauthToken}`)
   //     .then(data => {
   //       var songData = new Song();
   //       const spotifyData = JSON.parse(data);
@@ -23,11 +24,12 @@ router
   //     .catch(next);
   // });
   .get('/get-song/:id', (req, res, next) => {
-    rp(`${spotifyApi}/tracks/6lFfwR8W6Ha4cA7kvmclcv?access_token=${oauthToken}`)
+    rp(`${spotifyApi}/tracks/${req.params.id}?access_token=${oauthToken}`)
       .then(data => {
         var songData = new Song();
         const spotifyData = JSON.parse(data);
         songData.name = spotifyData.name;
+        songData.spotifySongId = spotifyData.id;
         songData.artists = [];
         spotifyData.artists.forEach(artists => {
           songData.artists.push(artists.name);
@@ -35,10 +37,16 @@ router
         songData.save();
         console.log(songData);
         res.send(songData);
-
       })
       .catch(next);
   });
+  // .get('get-songs/playlists/', (req, res, next) => {
+  //   Playlist.find()
+  //     .select()
+  //     .then(playlist => res.send(playlist))
+  //     .catch(next);
+  // });
+  //
 
 
 module.exports = router;


### PR DESCRIPTION
- Added a GET route to Spotify's 'tracks' (i.e. songs) API endpoint, including the Spotify Id for the track as the :id param will get the song and save it to the 'songs' collection in our DB

- updated the schema for the 'song' model

1. removed the 'genre' property

1. added a 'spotifySongId' property that is populated with the Spotify Id for the song