### PR TITLE
1118-0850 GroupUser Mutual Join PUT call

### DIFF
--- a/lib/routes/groups.js
+++ b/lib/routes/groups.js
@@ -44,7 +44,7 @@ router
             .catch(next);
     })
 
-  //"joins" user with group
+  //"joins" user with group and vice versa
   .put('/:groupId/users/:userId', bodyParser, (req, res, next) => {
     User.findByIdAndUpdate(req.params.userId)
             .then(user => {

--- a/public/scripts/publicGroups.js
+++ b/public/scripts/publicGroups.js
@@ -9,7 +9,6 @@
       const newGroupInfo = {
         groupName: $('#groupName-input').val(), // eslint-disable-line
         description: $('#groupDescription-input').val(), // eslint-disable-line
-        memberId: ['localStorage.currUserId'] // eslint-disable-line
       };
       $.ajax({ // eslint-disable-line
         method: 'POST',
@@ -22,6 +21,10 @@
 
       function successHandler(data) {
         console.log(data);
+        $.ajax({
+          type: 'PUT',
+          url:'api/groups/' + data._id + '/users/' + localStorage.currUserId
+        });
       }
 
       function errorHandler(err) {


### PR DESCRIPTION
Preexisting PUT Group/User mutual "join" piggybacked onto handleAddGroup's success call:

 function successHandler(data) {
        console.log(data);
        $.ajax({
          type: 'PUT',
          url:'api/groups/' + data._id + '/users/' + localStorage.currUserId
        });
      }

Thus, when adding new Group, Current User added to it, and the new Group added to the Current User.